### PR TITLE
Fix broken link under L2 -> broadcasting on arrays

### DIFF
--- a/lectures/L2_Basics_2.jl
+++ b/lectures/L2_Basics_2.jl
@@ -860,7 +860,7 @@ end
 # ╔═╡ b857984b-ec1b-4409-bdf0-438228950f39
 md"""# Broadcasting on arrays
 We've already seen broadcasting on vectors in the previous lecture.
-For higher-dimensional arrays, the behaviour is [a bit more complicated]((https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting)):
+For higher-dimensional arrays, the behaviour is [a bit more complicated](https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting):
 
 >  Broadcast **expands singleton dimensions in array arguments to match the corresponding dimension in the other array** without using extra memory, and applies the given function elementwise
 


### PR DESCRIPTION
This PR fixes a broken link in the L2_Basics_2.jl file. The previous URL returned a 404 due to double brackets around the link, and I’ve updated it to single brackets.